### PR TITLE
Add support for uncompressed or externally (de)compressed NBT streams

### DIFF
--- a/src/org/jnbt/NBTInputStream.java
+++ b/src/org/jnbt/NBTInputStream.java
@@ -76,11 +76,28 @@ public final class NBTInputStream implements Closeable {
 	 * 
 	 * @param is
 	 *            The input stream.
+	 * @param gzipped
+	 *            Whether the stream is GZip-compressed.
+	 * @throws IOException
+	 *             if an I/O error occurs.
+	 */
+	public NBTInputStream(InputStream is, final boolean gzipped) throws IOException {
+		if (gzipped) {
+			is = new GZIPInputStream(is);
+		}
+		this.is = new DataInputStream(is);
+	}
+	
+	/**
+	 * Creates a new <code>NBTInputStream</code>, which will source its data
+	 * from the specified GZIP-compressed input stream.
+	 * 
+	 * @param is
+	 *            The input stream.
 	 * @throws IOException
 	 *             if an I/O error occurs.
 	 */
 	public NBTInputStream(final InputStream is) throws IOException {
-	
 		this.is = new DataInputStream(new GZIPInputStream(is));
 	}
 	

--- a/src/org/jnbt/NBTOutputStream.java
+++ b/src/org/jnbt/NBTOutputStream.java
@@ -69,7 +69,7 @@ public final class NBTOutputStream implements Closeable {
 	
 	/**
 	 * Creates a new <code>NBTOutputStream</code>, which will write data to the
-	 * specified underlying output stream.
+	 * specified underlying output stream, GZip-compressed.
 	 * 
 	 * @param os
 	 *            The output stream.
@@ -79,6 +79,25 @@ public final class NBTOutputStream implements Closeable {
 	public NBTOutputStream(final OutputStream os) throws IOException {
 	
 		this.os = new DataOutputStream(new GZIPOutputStream(os));
+	}
+
+	
+	/**
+	 * Creates a new <code>NBTOutputStream</code>, which will write data to the
+	 * specified underlying output stream.
+	 * 
+	 * @param os
+	 *            The output stream.
+	 * @param gzipped
+	 *            Whether the output stream should be GZip-compressed.
+	 * @throws IOException
+	 *             if an I/O error occurs.
+	 */
+	public NBTOutputStream(OutputStream os, final boolean gzipped) throws IOException {
+		if (gzipped) {
+			os = new GZIPOutputStream(os);
+		}
+		this.os = new DataOutputStream(os);
 	}
 	
 	/**


### PR DESCRIPTION
The existing NBTInputStream and NBTOutputStream implicitly compress and decompress the stream with GZip. This breaks where other compression is used externally, for example DEFLATE compression in Minecraft region files (my use case).

This adds documentation to the methods saying that compression is used (would've saved me hours to see that) and an alternative constructor where whether or not to compress can be passed as an option. The existing constructor retains the original behaviour so as not to break any existing applications.
